### PR TITLE
fix: handle branch conflicts in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,8 +247,10 @@ jobs:
 
           # Ensure the branch is up-to-date before pushing
           git fetch origin main
-          git rebase origin/main || (echo "Rebase failed, but continuing with push attempt" && true)
-
+          if ! git rebase origin/main; then
+            echo "Rebase failed. Please resolve conflicts manually before retrying."
+            exit 1
+          fi
           # Push the branch with force-with-lease to handle any conflicts safely
           git push --force-with-lease origin $BRANCH_NAME || (
             # If push fails, try with a timestamp-based branch as fallback

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
           BRANCH_NAME="release-v${{ env.NEW_VERSION }}"
 
           # Check if the branch already exists remotely
-          if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
+          if git ls-remote --heads origin $BRANCH_NAME | grep -q "$BRANCH_NAME"; then
             echo "Branch $BRANCH_NAME already exists remotely. Using a unique branch name instead."
             TIMESTAMP=$(date +%Y%m%d%H%M%S)
             BRANCH_NAME="release-v${{ env.NEW_VERSION }}-$TIMESTAMP"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,14 @@ jobs:
         run: |
           # Create and switch to a new branch
           BRANCH_NAME="release-v${{ env.NEW_VERSION }}"
+
+          # Check if the branch already exists remotely
+          if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
+            echo "Branch $BRANCH_NAME already exists remotely. Using a unique branch name instead."
+            TIMESTAMP=$(date +%Y%m%d%H%M%S)
+            BRANCH_NAME="release-v${{ env.NEW_VERSION }}-$TIMESTAMP"
+          fi
+
           git checkout -b $BRANCH_NAME
 
           # Stage and commit the changes
@@ -231,14 +239,25 @@ jobs:
 
           # Check if the tag already exists
           if git rev-parse "v${{ env.NEW_VERSION }}" >/dev/null 2>&1; then
-            echo "Tag v${{ env.NEW_VERSION }} already exists. Skipping tag creation."
+            echo "Tag v${{ env.NEW_VERSION }} already exists. Skipping tag creation and push."
           else
             git tag -a v${{ env.NEW_VERSION }} -m "Release v${{ env.NEW_VERSION }}"
             git push origin v${{ env.NEW_VERSION }}
           fi
 
-          # Push the branch (always, regardless of whether the tag exists)
-          git push origin $BRANCH_NAME
+          # Ensure the branch is up-to-date before pushing
+          git fetch origin main
+          git rebase origin/main || (echo "Rebase failed, but continuing with push attempt" && true)
+
+          # Push the branch with force-with-lease to handle any conflicts safely
+          git push --force-with-lease origin $BRANCH_NAME || (
+            # If push fails, try with a timestamp-based branch as fallback
+            FALLBACK_BRANCH="release-v${{ env.NEW_VERSION }}-$(date +%Y%m%d%H%M%S)"
+            echo "Push failed, trying with fallback branch $FALLBACK_BRANCH"
+            git checkout -b $FALLBACK_BRANCH
+            git push origin $FALLBACK_BRANCH
+            BRANCH_NAME=$FALLBACK_BRANCH
+          )
 
           # Create a pull request (without label if it doesn't exist)
           gh pr create --title "Release v${{ env.NEW_VERSION }}" \


### PR DESCRIPTION
- Add check for existing remote branch with timestamp-based unique names
- Add fetch and rebase before pushing to ensure branch is up-to-date
- Use force-with-lease to safely handle potential conflicts
- Add fallback mechanism with timestamp-based branch name if push fails
- Ensure tag handling is separate from branch handling